### PR TITLE
Add acceptedResourceRoles for * and slave_public

### DIFF
--- a/node_exporter.json
+++ b/node_exporter.json
@@ -18,5 +18,9 @@
       "portIndex": 0,
       "protocol": "HTTP"
     }
+  ],
+  "acceptedResourceRoles": [
+    "*",
+    "slave_public"
   ]
 }


### PR DESCRIPTION
It'd be advisable for this to also run on public nodes in addition to private nodes. Adding "*" and "slave_public" as "acceptedResourceRoles" achieves that.